### PR TITLE
Fix: prevent calling custom column names from raising missing attributes

### DIFF
--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -5,6 +5,7 @@ gem 'activerecord', '~> 6.0.0'
 group :test do
   gem 'simplecov', '< 0.18'
   gem 'mysql2', '0.5.3'
+  gem 'acts-as-taggable-on', '~> 7.0.0'
 end
 
 gemspec path: '../'

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -5,6 +5,7 @@ gem 'activerecord', '~> 6.1.3'
 group :test do
   gem 'simplecov', '< 0.18'
   gem 'mysql2', '0.5.3'
+  gem 'acts-as-taggable-on', '~> 7.0.0'
 end
 
 gemspec path: '../'

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -6,6 +6,7 @@ gem 'activerecord', '~> 7.0.0'
 group :test do
   gem 'simplecov', '< 0.18'
   gem 'mysql2', '0.5.3'
+  gem 'acts-as-taggable-on', '~> 9.0.0'
 end
 
 gemspec path: '../'

--- a/lib/adaptive_alias.rb
+++ b/lib/adaptive_alias.rb
@@ -61,5 +61,13 @@ module AdaptiveAlias
       klass.prepend(@model_modules[klass])
       return @model_modules[klass]
     end
+
+    def missing_value?(attributes, klass, name)
+      return false if attributes.key?(name)
+
+      old_name = klass.attribute_aliases.key(name)
+      return false if old_name == nil
+      return !!AdaptiveAlias.current_patches[[klass, old_name.to_sym, name.to_sym]]
+    end
   end
 end

--- a/lib/adaptive_alias/active_model_patches/read_attribute.rb
+++ b/lib/adaptive_alias/active_model_patches/read_attribute.rb
@@ -14,7 +14,7 @@ module ActiveRecord::AttributeMethods::Read
     name = self.class.attribute_aliases[name] || name
 
     sync_with_transaction_state if @transaction_state&.finalized?
-    return yield if block_given? && !@attributes.key?(name)
-    @attributes.fetch_value(name, &block)
+    return yield if block_given? and AdaptiveAlias.missing_value?(@attributes, self.class, name)
+    return @attributes.fetch_value(name, &block)
   end
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -9,4 +9,6 @@ class User < ActiveRecord::Base
   has_many :active_articles, ->{ where(active: true) }, class_name: 'Article'
 
   belongs_to :profile
+
+  acts_as_taggable
 end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -21,6 +21,20 @@ ActiveRecord::Schema.define do
   create_table :profiles, force: true do |t|
     t.string :id_number
   end
+
+  create_table :tags, force: true do |t|
+    t.string :name
+    t.integer :taggings_count
+  end
+
+  create_table :taggings, force: true do |t|
+    t.integer :tag_id
+    t.string :taggable_type
+    t.integer :taggable_id
+    t.string :tagger_type
+    t.integer :tagger_id
+    t.string :context
+  end
 end
 
 require 'rails_compatibility/setup_autoload_paths'
@@ -30,6 +44,9 @@ users = User.create([
   { name: 'Doggy', profile: Profile.new(id_number: 'A1234') },
   { name: 'Catty', profile: Profile.new(id_number: 'B1234') },
 ])
+
+users[0].tag_list.add('awesome', 'slick')
+users[0].save
 
 Post.create([
   { title: 'Post A1', user_id_old: users[0].id, active: true },

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require 'minitest/autorun'
 
 require 'lib/mysql2_connection'
 
+require 'acts-as-taggable-on'
 require 'lib/seeds'
 
 Warning[:deprecated] = false if Warning.respond_to?(:[]) # Warning#[] is not defined in Ruby 2.6.


### PR DESCRIPTION
Ex: `acts-as-taggable` will call `model['cached_tag_list']` which will be considered as missing value in previous implementation.