### PR TITLE
[Fix] Nested module include is not supported until ruby 3.0

### DIFF
--- a/lib/adaptive_alias/active_model_patches/read_attribute.rb
+++ b/lib/adaptive_alias/active_model_patches/read_attribute.rb
@@ -25,6 +25,7 @@ module AdaptiveAlias
   end
 end
 
-module ActiveRecord::AttributeMethods::Read
+# Nested module include is not supported until ruby 3.0
+class ActiveRecord::Base
   prepend AdaptiveAlias::ActiveModelPatches::ReadAttribute
 end

--- a/lib/adaptive_alias/active_model_patches/remove_alias_attribute.rb
+++ b/lib/adaptive_alias/active_model_patches/remove_alias_attribute.rb
@@ -19,6 +19,13 @@ module AdaptiveAlias
   end
 end
 
-module ActiveModel::AttributeMethods::ClassMethods
-  include AdaptiveAlias::ActiveModelPatches::RemoveAliasAttribute
+# Nested module include is not supported until ruby 3.0
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')
+  AdaptiveAlias::ActiveModelPatches::RemoveAliasAttribute.instance_methods.each do |method|
+    ActiveModel::AttributeMethods::ClassMethods.define_method(method, AdaptiveAlias::ActiveModelPatches::RemoveAliasAttribute.instance_method(method))
+  end
+else
+  module ActiveModel::AttributeMethods::ClassMethods
+    include AdaptiveAlias::ActiveModelPatches::RemoveAliasAttribute
+  end
 end

--- a/lib/adaptive_alias/active_model_patches/write_attribute.rb
+++ b/lib/adaptive_alias/active_model_patches/write_attribute.rb
@@ -20,6 +20,6 @@ module AdaptiveAlias
   end
 end
 
-module ActiveRecord::AttributeMethods::Write
+class ActiveRecord::Base
   prepend AdaptiveAlias::ActiveModelPatches::WriteAttribute
 end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -39,8 +39,8 @@ class ProfileTest < Minitest::Test
   def test_write
     user = User.find_by(name: 'Catty')
     assert_queries(0) do
-      user.profile_id = 1
-      user.profile_id_new = 1
+      user.profile_id = 123
+      user.profile_id_new = 123
     end
 
     3.times do
@@ -48,16 +48,20 @@ class ProfileTest < Minitest::Test
       Article.connection.rename_column :users, :profile_id, :profile_id_new
       user = User.find_by(name: 'Catty')
       assert_queries(0) do
-        user.profile_id = 1
-        user.profile_id_new = 1
+        user.profile_id = 123
+        user.profile_id_new = 123
+        assert_equal 123, user.profile_id
+        assert_equal 123, user.profile_id_new
       end
 
       # --------- rollback rename migration ---------
       Article.connection.rename_column :users, :profile_id_new, :profile_id
       user = User.find_by(name: 'Catty')
       assert_queries(0) do
-        user.profile_id = 1
-        user.profile_id_new = 1
+        user.profile_id = 123
+        user.profile_id_new = 123
+        assert_equal 123, user.profile_id
+        assert_equal 123, user.profile_id_new
       end
     end
   end
@@ -84,7 +88,8 @@ class ProfileTest < Minitest::Test
       user = User.find_by(name: 'Catty')
 
       assert_queries(0) do
-        user.profile_id_new = 1
+        user.profile_id_new = 123
+        assert_equal 123, user.profile_id_new
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,12 +5,13 @@ SimpleCov.start 'test_frameworks'
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require 'adaptive_alias'
 require 'minitest/autorun'
 
 require 'lib/mysql2_connection'
 
 require 'acts-as-taggable-on'
+
+require 'adaptive_alias'
 require 'lib/seeds'
 
 Warning[:deprecated] = false if Warning.respond_to?(:[]) # Warning#[] is not defined in Ruby 2.6.


### PR DESCRIPTION
It will raise undefined method `remove_alias_attribute' in ruby 2.x