### PR TITLE
[Fix] Fail to use backward-patch when target column has already been migrated

### DIFF
--- a/lib/adaptive_alias.rb
+++ b/lib/adaptive_alias.rb
@@ -33,7 +33,7 @@ module AdaptiveAlias
         extend ActiveSupport::Concern
 
         included do
-          patch = (column_names.include?(new_column) ? Patches::BackwardPatch : Patches::ForwardPatch).new(self, old_column, new_column)
+          patch = (column_names.include?(new_column.to_s) ? Patches::BackwardPatch : Patches::ForwardPatch).new(self, old_column, new_column)
           patch.apply!
           patch.mark_removable
         end

--- a/test/has_many_test/papers_test.rb
+++ b/test/has_many_test/papers_test.rb
@@ -1,0 +1,276 @@
+require 'test_helper'
+
+class PapersTest < Minitest::Test
+  def setup
+  end
+
+  def teardown
+    restore_original_db_schema!(Paper, :new_user_id, :user_id, false)
+  end
+
+  def test_first
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} ORDER BY `papers`.`id` ASC LIMIT 1",
+    ]) do
+      assert_equal 'Paper B1', user.papers.first.title
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} ORDER BY `papers`.`id` ASC LIMIT 1",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id} ORDER BY `papers`.`id` ASC LIMIT 1",
+      ]) do
+        assert_equal 'Paper B1', user.papers.first.title
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id} ORDER BY `papers`.`id` ASC LIMIT 1",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} ORDER BY `papers`.`id` ASC LIMIT 1",
+      ]) do
+        assert_equal 'Paper B1', user.papers.first.title
+      end
+    end
+  end
+
+  def test_last
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} ORDER BY `papers`.`id` DESC LIMIT 1",
+    ]) do
+      assert_equal 'Paper B3', user.papers.last.title
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} ORDER BY `papers`.`id` DESC LIMIT 1",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id} ORDER BY `papers`.`id` DESC LIMIT 1",
+      ]) do
+        assert_equal 'Paper B3', user.papers.last.title
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id} ORDER BY `papers`.`id` DESC LIMIT 1",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} ORDER BY `papers`.`id` DESC LIMIT 1",
+      ]) do
+        assert_equal 'Paper B3', user.papers.last.title
+      end
+    end
+  end
+
+  def test_to_a
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id}",
+    ]) do
+      assert_equal ['Paper B1', 'Paper B2', 'Paper B3'], user.papers.map(&:title)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id}",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id}",
+      ]) do
+        assert_equal ['Paper B1', 'Paper B2', 'Paper B3'], user.papers.map(&:title)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id}",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id}",
+      ]) do
+        assert_equal ['Paper B1', 'Paper B2', 'Paper B3'], user.papers.map(&:title)
+      end
+    end
+  end
+
+  def test_to_a_with_default_scope
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} AND `papers`.`active` = TRUE",
+    ]) do
+      assert_equal ['Paper B2'], user.active_papers.map(&:title)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} AND `papers`.`active` = TRUE",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id} AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['Paper B2'], user.active_papers.map(&:title)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`user_id` = #{user.id} AND `papers`.`active` = TRUE",
+        "SELECT `papers`.* FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['Paper B2'], user.active_papers.map(&:title)
+      end
+    end
+  end
+
+  def test_pluck
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`new_user_id` = #{user.id}",
+    ]) do
+      assert_equal ['Paper B1', 'Paper B2', 'Paper B3'], user.papers.pluck(:title)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`new_user_id` = #{user.id}",
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`user_id` = #{user.id}",
+      ]) do
+        assert_equal ['Paper B1', 'Paper B2', 'Paper B3'], user.papers.pluck(:title)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`user_id` = #{user.id}",
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`new_user_id` = #{user.id}",
+      ]) do
+        assert_equal ['Paper B1', 'Paper B2', 'Paper B3'], user.papers.pluck(:title)
+      end
+    end
+  end
+
+  def test_where_and_pluck
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} AND `papers`.`active` = TRUE",
+    ]) do
+      assert_equal ['Paper B2'], user.papers.where(active: true).pluck(:title)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} AND `papers`.`active` = TRUE",
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`user_id` = #{user.id} AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['Paper B2'], user.papers.where(active: true).pluck(:title)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`user_id` = #{user.id} AND `papers`.`active` = TRUE",
+        "SELECT `papers`.`title` FROM `papers` WHERE `papers`.`new_user_id` = #{user.id} AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['Paper B2'], user.papers.where(active: true).pluck(:title)
+      end
+    end
+  end
+
+  def test_create
+    user = User.find_by(name: 'Catty')
+    post = nil
+
+    assert_queries([
+      "INSERT INTO `papers` (`new_user_id`, `title`) VALUES (2, 'new post')",
+    ]) do
+      post = user.papers.create!(title: 'new post')
+    end
+
+    post.destroy
+    post = nil
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "INSERT INTO `papers` (`new_user_id`, `title`) VALUES (2, 'new post')",
+        'ROLLBACK',
+        "INSERT INTO `papers` (`user_id`, `title`) VALUES (2, 'new post')",
+      ]) do
+        post = user.papers.create!(title: 'new post')
+      end
+
+      post.destroy
+      post = nil
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "INSERT INTO `papers` (`user_id`, `title`) VALUES (2, 'new post')",
+        'ROLLBACK',
+        "INSERT INTO `papers` (`new_user_id`, `title`) VALUES (2, 'new post')",
+      ]) do
+        post = user.papers.create!(title: 'new post')
+      end
+
+      post.destroy
+      post = nil
+    end
+  ensure
+    post.destroy if post
+  end
+
+  def test_destroy
+    user = User.find_by(name: 'Catty')
+    papers = Array.new(7){ user.papers.create!(title: 'new post') }
+
+    assert_queries([
+      "DELETE FROM `papers` WHERE `papers`.`id` = #{papers.last.id}",
+    ]) do
+      papers.pop.destroy!
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      assert_queries([
+        "DELETE FROM `papers` WHERE `papers`.`id` = #{papers.last.id}",
+      ]) do
+        papers.pop.destroy!
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      assert_queries([
+        "DELETE FROM `papers` WHERE `papers`.`id` = #{papers.last.id}",
+      ]) do
+        papers.pop.destroy!
+      end
+    end
+  ensure
+    papers.each(&:destroy!)
+    papers.clear
+  end
+end

--- a/test/has_many_through_test/papers_reviews_test.rb
+++ b/test/has_many_through_test/papers_reviews_test.rb
@@ -1,0 +1,196 @@
+require 'test_helper'
+
+class PapersReviewsTest < Minitest::Test
+  def setup
+  end
+
+  def teardown
+    restore_original_db_schema!(Paper, :new_user_id, :user_id, false)
+  end
+
+  def test_first
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` ASC LIMIT 1",
+    ]) do
+      assert_equal 'paper review B1', user.papers_reviews.first.content
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` ASC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` ASC LIMIT 1",
+      ]) do
+        assert_equal 'paper review B1', user.papers_reviews.first.content
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` ASC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` ASC LIMIT 1",
+      ]) do
+        assert_equal 'paper review B1', user.papers_reviews.first.content
+      end
+    end
+  end
+
+  def test_last
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` DESC LIMIT 1",
+    ]) do
+      assert_equal 'paper review C1', user.papers_reviews.last.content
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` DESC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` DESC LIMIT 1",
+      ]) do
+        assert_equal 'paper review C1', user.papers_reviews.last.content
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` DESC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' ORDER BY `reviews`.`id` DESC LIMIT 1",
+      ]) do
+        assert_equal 'paper review C1', user.papers_reviews.last.content
+      end
+    end
+  end
+
+  def test_to_a
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+    ]) do
+      assert_equal ['paper review B1', 'paper review B2', 'paper review C1'], user.papers_reviews.map(&:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+      ]) do
+        assert_equal ['paper review B1', 'paper review B2', 'paper review C1'], user.papers_reviews.map(&:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+      ]) do
+        assert_equal ['paper review B1', 'paper review B2', 'paper review C1'], user.papers_reviews.map(&:content)
+      end
+    end
+  end
+
+  def test_to_a_with_default_scope
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+    ]) do
+      assert_equal ['paper review C1'], user.active_papers_reviews.map(&:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['paper review C1'], user.active_papers_reviews.map(&:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['paper review C1'], user.active_papers_reviews.map(&:content)
+      end
+    end
+  end
+
+  def test_pluck
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+    ]) do
+      assert_equal ['paper review B1', 'paper review B2', 'paper review C1'], user.papers_reviews.pluck(:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+      ]) do
+        assert_equal ['paper review B1', 'paper review B2', 'paper review C1'], user.papers_reviews.pluck(:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper'",
+      ]) do
+        assert_equal ['paper review B1', 'paper review B2', 'paper review C1'], user.papers_reviews.pluck(:content)
+      end
+    end
+  end
+
+  def test_where_and_pluck
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+    ]) do
+      assert_equal ['paper review C1'], user.papers_reviews.merge(Paper.where(active: true)).pluck(:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Paper.connection.rename_column :papers, :new_user_id, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['paper review C1'], user.papers_reviews.merge(Paper.where(active: true)).pluck(:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Paper.connection.rename_column :papers, :user_id, :new_user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `papers` ON `reviews`.`reviewable_id` = `papers`.`id` WHERE `papers`.`new_user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Paper' AND `papers`.`active` = TRUE",
+      ]) do
+        assert_equal ['paper review C1'], user.papers_reviews.merge(Paper.where(active: true)).pluck(:content)
+      end
+    end
+  end
+end

--- a/test/has_many_through_test/posts_reviews_test.rb
+++ b/test/has_many_through_test/posts_reviews_test.rb
@@ -1,0 +1,196 @@
+require 'test_helper'
+
+class PostsReviewsTest < Minitest::Test
+  def setup
+  end
+
+  def teardown
+    restore_original_db_schema!(Post, :user_id_old, :user_id)
+  end
+
+  def test_first
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` ASC LIMIT 1",
+    ]) do
+      assert_equal 'post review B1', user.posts_reviews.first.content
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Post.connection.rename_column :posts, :user_id_old, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` ASC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` ASC LIMIT 1",
+      ]) do
+        assert_equal 'post review B1', user.posts_reviews.first.content
+      end
+
+      # --------- rollback rename migration ---------
+      Post.connection.rename_column :posts, :user_id, :user_id_old
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` ASC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` ASC LIMIT 1",
+      ]) do
+        assert_equal 'post review B1', user.posts_reviews.first.content
+      end
+    end
+  end
+
+  def test_last
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` DESC LIMIT 1",
+    ]) do
+      assert_equal 'post review C1', user.posts_reviews.last.content
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Post.connection.rename_column :posts, :user_id_old, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` DESC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` DESC LIMIT 1",
+      ]) do
+        assert_equal 'post review C1', user.posts_reviews.last.content
+      end
+
+      # --------- rollback rename migration ---------
+      Post.connection.rename_column :posts, :user_id, :user_id_old
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` DESC LIMIT 1",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' ORDER BY `reviews`.`id` DESC LIMIT 1",
+      ]) do
+        assert_equal 'post review C1', user.posts_reviews.last.content
+      end
+    end
+  end
+
+  def test_to_a
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+    ]) do
+      assert_equal ['post review B1', 'post review B2', 'post review C1'], user.posts_reviews.map(&:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Post.connection.rename_column :posts, :user_id_old, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+      ]) do
+        assert_equal ['post review B1', 'post review B2', 'post review C1'], user.posts_reviews.map(&:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Post.connection.rename_column :posts, :user_id, :user_id_old
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+      ]) do
+        assert_equal ['post review B1', 'post review B2', 'post review C1'], user.posts_reviews.map(&:content)
+      end
+    end
+  end
+
+  def test_to_a_with_default_scope
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+    ]) do
+      assert_equal ['post review C1'], user.active_posts_reviews.map(&:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Post.connection.rename_column :posts, :user_id_old, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+      ]) do
+        assert_equal ['post review C1'], user.active_posts_reviews.map(&:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Post.connection.rename_column :posts, :user_id, :user_id_old
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+        "SELECT `reviews`.* FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+      ]) do
+        assert_equal ['post review C1'], user.active_posts_reviews.map(&:content)
+      end
+    end
+  end
+
+  def test_pluck
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+    ]) do
+      assert_equal ['post review B1', 'post review B2', 'post review C1'], user.posts_reviews.pluck(:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Post.connection.rename_column :posts, :user_id_old, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+      ]) do
+        assert_equal ['post review B1', 'post review B2', 'post review C1'], user.posts_reviews.pluck(:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Post.connection.rename_column :posts, :user_id, :user_id_old
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post'",
+      ]) do
+        assert_equal ['post review B1', 'post review B2', 'post review C1'], user.posts_reviews.pluck(:content)
+      end
+    end
+  end
+
+  def test_where_and_pluck
+    user = User.find_by(name: 'Catty')
+    assert_queries([
+      "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+    ]) do
+      assert_equal ['post review C1'], user.posts_reviews.merge(Post.where(active: true)).pluck(:content)
+    end
+
+    3.times do
+      # --------- do rename migration ---------
+      Post.connection.rename_column :posts, :user_id_old, :user_id
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+      ]) do
+        assert_equal ['post review C1'], user.posts_reviews.merge(Post.where(active: true)).pluck(:content)
+      end
+
+      # --------- rollback rename migration ---------
+      Post.connection.rename_column :posts, :user_id, :user_id_old
+      user = User.find_by(name: 'Catty')
+      assert_queries([
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+        "SELECT `reviews`.`content` FROM `reviews` INNER JOIN `posts` ON `reviews`.`reviewable_id` = `posts`.`id` WHERE `posts`.`user_id_old` = #{user.id} AND `reviews`.`reviewable_type` = 'Post' AND `posts`.`active` = TRUE",
+      ]) do
+        assert_equal ['post review C1'], user.posts_reviews.merge(Post.where(active: true)).pluck(:content)
+      end
+    end
+  end
+end

--- a/test/lib/models/paper.rb
+++ b/test/lib/models/paper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Paper < ActiveRecord::Base
+  include AdaptiveAlias[:user_id, :new_user_id]
+
+  belongs_to :user
+end

--- a/test/lib/models/paper.rb
+++ b/test/lib/models/paper.rb
@@ -3,4 +3,5 @@ class Paper < ActiveRecord::Base
   include AdaptiveAlias[:user_id, :new_user_id]
 
   belongs_to :user
+  has_many :reviews, as: :reviewable
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -12,6 +12,9 @@ class User < ActiveRecord::Base
   has_many :articles_reviews, through: :articles, source: :reviews, class_name: 'Review'
   has_many :active_articles_reviews, through: :active_articles, source: :reviews, class_name: 'Review'
 
+  has_many :papers
+  has_many :active_papers, ->{ where(active: true) }, class_name: 'Paper'
+
   belongs_to :profile
 
   acts_as_taggable

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -14,6 +14,8 @@ class User < ActiveRecord::Base
 
   has_many :papers
   has_many :active_papers, ->{ where(active: true) }, class_name: 'Paper'
+  has_many :papers_reviews, through: :papers, source: :reviews, class_name: 'Review'
+  has_many :active_papers_reviews, through: :active_papers, source: :reviews, class_name: 'Review'
 
   belongs_to :profile
 

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -18,6 +18,12 @@ ActiveRecord::Schema.define do
     t.boolean :active
   end
 
+  create_table :papers, force: true do |t|
+    t.integer :new_user_id
+    t.string :title
+    t.boolean :active
+  end
+
   create_table :profiles, force: true do |t|
     t.string :id_number
   end
@@ -45,15 +51,15 @@ end
 require 'rails_compatibility/setup_autoload_paths'
 RailsCompatibility.setup_autoload_paths [File.expand_path('../models/', __FILE__)]
 
-users = User.create([
+users = User.create!([
   { name: 'Doggy', profile: Profile.new(id_number: 'A1234') },
   { name: 'Catty', profile: Profile.new(id_number: 'B1234') },
 ])
 
 users[0].tag_list.add('awesome', 'slick')
-users[0].save
+users[0].save!
 
-posts = Post.create([
+posts = Post.create!([
   { title: 'Post A1', user_id_old: users[0].id, active: true },
   { title: 'Post B1', user_id_old: users[1].id, active: false },
   { title: 'Post B2', user_id_old: users[1].id, active: true },
@@ -65,7 +71,7 @@ posts[1].reviews.create!(content: 'post review B1')
 posts[1].reviews.create!(content: 'post review B2')
 posts[2].reviews.create!(content: 'post review C1')
 
-articles = Article.create([
+articles = Article.create!([
   { title: 'Article A1', user_id: users[0].id, active: true },
   { title: 'Article B1', user_id: users[1].id, active: false },
   { title: 'Article B2', user_id: users[1].id, active: true },
@@ -76,3 +82,10 @@ articles[0].reviews.create!(content: 'article review A1')
 articles[1].reviews.create!(content: 'article review B1')
 articles[1].reviews.create!(content: 'article review B2')
 articles[2].reviews.create!(content: 'article review C1')
+
+Paper.create!([
+  { title: 'Paper A1', new_user_id: users[0].id, active: true },
+  { title: 'Paper B1', new_user_id: users[1].id, active: false },
+  { title: 'Paper B2', new_user_id: users[1].id, active: true },
+  { title: 'Paper B3', new_user_id: users[1].id, active: false },
+])

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -83,9 +83,14 @@ articles[1].reviews.create!(content: 'article review B1')
 articles[1].reviews.create!(content: 'article review B2')
 articles[2].reviews.create!(content: 'article review C1')
 
-Paper.create!([
+papers = Paper.create!([
   { title: 'Paper A1', new_user_id: users[0].id, active: true },
   { title: 'Paper B1', new_user_id: users[1].id, active: false },
   { title: 'Paper B2', new_user_id: users[1].id, active: true },
   { title: 'Paper B3', new_user_id: users[1].id, active: false },
 ])
+
+papers[0].reviews.create!(content: 'paper review A1')
+papers[1].reviews.create!(content: 'paper review B1')
+papers[1].reviews.create!(content: 'paper review B2')
+papers[2].reviews.create!(content: 'paper review C1')


### PR DESCRIPTION
column_names is string array, not symbol array